### PR TITLE
Change homebrew paths so they're not hardcoded

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class rabbitmq::config {
   $configfile     = "${configdir}/rabbitmq.conf"
   $enabledplugins = "${configdir}/enabled_plugins"
   $datadir        = "${boxen::config::datadir}/rabbitmq"
-  $executable     = "${boxen::config::home}/homebrew/sbin/rabbitmq-server"
+  $executable     = "${boxen::config::homebrewdir}/sbin/rabbitmq-server"
   $logdir         = "${boxen::config::logdir}/rabbitmq"
   $port           = 55672
   $mgmt_port      = 15672

--- a/templates/dev.rabbitmq.plist.erb
+++ b/templates/dev.rabbitmq.plist.erb
@@ -24,7 +24,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin</string>
+      <string><%= scope.lookupvar "boxen::config::homebrewdir" %>/sbin:<%= scope.lookupvar "boxen::config::homebrewdir" %>/bin:/usr/bin:/bin</string>
 
       <key>RABBITMQ_CONFIG_FILE</key>
       <string><%= scope.lookupvar "rabbitmq::config::configdir" %>/rabbitmq</string>


### PR DESCRIPTION
Homebrew isn't necessarily installed under /opt/boxen. Many install it
under /usr/local today.
