### PR TITLE
Location of rabbitmq executable has changed

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class rabbitmq::config {
   $configfile     = "${configdir}/rabbitmq.conf"
   $enabledplugins = "${configdir}/enabled_plugins"
   $datadir        = "${boxen::config::datadir}/rabbitmq"
-  $executable     = "${boxen::config::home}/homebrew/sbin/rabbitmq-server"
+  $executable     = "/usr/local/sbin/rabbitmq-server"
   $logdir         = "${boxen::config::logdir}/rabbitmq"
   $port           = 55672
   $mgmt_port      = 15672

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,6 +12,6 @@ class rabbitmq::config {
   $datadir        = "${boxen::config::datadir}/rabbitmq"
   $executable     = "/usr/local/sbin/rabbitmq-server"
   $logdir         = "${boxen::config::logdir}/rabbitmq"
-  $port           = 55672
-  $mgmt_port      = 15672
+  $port           = 15672 
+  $mgmt_port      = 65672 
 }

--- a/templates/dev.rabbitmq.plist.erb
+++ b/templates/dev.rabbitmq.plist.erb
@@ -24,7 +24,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin</string>
+      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin:/usr/bin/local</string>
 
       <key>RABBITMQ_CONFIG_FILE</key>
       <string><%= scope.lookupvar "rabbitmq::config::configdir" %>/rabbitmq</string>

--- a/templates/dev.rabbitmq.plist.erb
+++ b/templates/dev.rabbitmq.plist.erb
@@ -24,7 +24,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin:/usr/bin/local</string>
+      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin:/usr/local/sbin</string>
 
       <key>RABBITMQ_CONFIG_FILE</key>
       <string><%= scope.lookupvar "rabbitmq::config::configdir" %>/rabbitmq</string>

--- a/templates/dev.rabbitmq.plist.erb
+++ b/templates/dev.rabbitmq.plist.erb
@@ -24,7 +24,7 @@
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin:/usr/local/sbin</string>
+      <string><%= scope.lookupvar "boxen::config::home" %>/homebrew/sbin:<%= scope.lookupvar "boxen::config::home" %>/homebrew/bin:/usr/bin:/usr/local/bin:/usr/local/sbin</string>
 
       <key>RABBITMQ_CONFIG_FILE</key>
       <string><%= scope.lookupvar "rabbitmq::config::configdir" %>/rabbitmq</string>


### PR DESCRIPTION
Since https://github.com/boxen/puppet-homebrew/commit/d49adf31508a3a218c2da5a4b42ba343e6183200 the location of homebrew has changed to /usr/local, and with it the location of rabbitmq.
